### PR TITLE
config: Clear Google Maps API Key in AndroidManifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -29,7 +29,7 @@
         <!-- Google Maps API Key -->
         <meta-data
             android:name="com.google.android.geo.API_KEY"
-            android:value="AIzaSyD4DsyVCuqqmlIUOeFg1nIpZLDxuU3956k"/>
+            android:value=""/>
 
         <meta-data
             android:name="flutterEmbedding"


### PR DESCRIPTION
The Google Maps API key has been removed from the `AndroidManifest.xml` file.